### PR TITLE
Adjust batch size

### DIFF
--- a/awslogs_sd/awslogs_sd.py
+++ b/awslogs_sd/awslogs_sd.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import os
 import time
 import itertools
 import logging
@@ -25,7 +26,7 @@ from .metrics import metrics, metrics_task
 
 # cloudwatch doesn't allow batch spans larger than 24h
 MAX_BATCH_TIME_SPAN = timedelta(hours=24)
-MAX_BATCH_ITEMS = 100
+MAX_BATCH_ITEMS = os.getenv('AWSLOGS_SD_MAX_BATCH_ITEMS', 100)
 BATCH_TIMEOUT_S = 1.0
 MAX_QUEUE_SIZE = 100000
 

--- a/awslogs_sd/awslogs_sd.py
+++ b/awslogs_sd/awslogs_sd.py
@@ -411,8 +411,13 @@ def create_log_streams(conf):
     for unit_conf in conf.units:
         group = unit_conf.log_group_name
         name = unit_conf.log_stream_name
+        all_streams = []
         resp = client.describe_log_streams(logGroupName=group)
-        matches = [g for g in resp['logStreams'] if g['logStreamName'] == name]
+        all_streams += resp['logStreams']
+        while 'nextToken' in resp:
+          resp = client.describe_log_streams(logGroupName=group, nextToken=resp['nextToken'])
+          all_streams += resp['logStreams']
+        matches = [g for g in all_streams if g['logStreamName'] == name]
         if not matches:
             logger.info('Creating log stream: %s', name)
             client.create_log_stream(logGroupName=group, logStreamName=name)

--- a/awslogs_sd/awslogs_sd.py
+++ b/awslogs_sd/awslogs_sd.py
@@ -73,7 +73,8 @@ RFC_SYSLOG_FACILITIES = {
     'local7': 23,
 }
 
-
+loglevel = os.getenv('AWSLOGS_SD_LOGLEVEL', logging.WARNING)
+logging.basicConfig(level=loglevel)
 logger = logging.getLogger('awslogs')
 
 


### PR DESCRIPTION
These adjustments are primarily to make operation a little smoother:

 * allow `MAX_BATCH_ITEMS` to be adjusted through an environment variable
 * handle checking more than 50 log streams before creating
 * adjust log level through environment variable