### PR TITLE
pin python-dateutil to 2.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'requests',
         'retrying',
         'systemd-python',
+        'python-dateutil<2.8.1'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This should clear up the `awslogs-sd` issue for those instances, I'll need to implement this manually, but it should be pretty straight forward.