### PR TITLE
Pin PyYAML to version 5.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'awscli-cwlogs',
         'boto3',
         'gevent',
-        'pyyaml',
+        'PyYAML==5.3.1',
         'requests',
         'retrying',
         'systemd-python',


### PR DESCRIPTION
The stable `awscli` library [requires PyYAML<5.4](https://github.com/aws/aws-cli/blob/master/setup.py#L38), this change pins us to the latest working version of the dependency.